### PR TITLE
OCR multi lang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To stop the server:
 - [Benchmarks](#benchmarks)
   - [Performance](#performance)
   - [Speed](#speed)
+- [Installation of More Languages for OCR](#installation-of-more-languages-for-ocr)
 - [Related Services](#related-services)
 
 ## Dependencies
@@ -269,13 +270,16 @@ More languages can be used by installing them in the docker container or install
 
 To install more languages in the docker container, you can use the following command after the container is running:
 
-    docker exec -it --user root {CONTAINER_ID} /bin/bash
+    docker exec -it --user root pdf-document-layout-analysis /bin/bash
     apt-get install tesseract-ocr-[LANGCODES]
 
 > Tesseract LANGCODES can be found in the values of the [iso_to_tesseract dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py).
 
-After installing the languages into your container you should be able to see them in the response of the */info* endpoint.
+After installing the languages into your container you should be able to see them by running:
 
+```
+curl localhost:5060/info
+```
 
 
 ## Related Services

--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ Run the service:
 
     curl -X POST -F 'language=en' -F 'file=@/PATH/TO/PDF/pdf_name.pdf' localhost:5060/ocr --output ocr_document.pdf
 
-You can also install new languages with:
-
-    curl -X POST -F 'language={ISO}' localhost:5060/ocr_add_language
-
->  The language code should be in ISO 639-1 format. All languages and scripts supported by Tesseract OCR can be found [here](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html). The possible values are stored in the keys of the [iso_to_tessarct dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py)
-
 
 Get the segments from a PDF:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Run the service:
 
     curl -X POST -F 'language=en' -F 'file=@/PATH/TO/PDF/pdf_name.pdf' localhost:5060/ocr --output ocr_document.pdf
 
+You can also install new languages with:
+
+    curl -X POST -F 'language={ISO}' localhost:5060/ocr_add_language
+
+>  The language code should be in ISO 639-1 format. All languages and scripts supported by Tesseract OCR can be found [here](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html). The possible values are stored in the keys of the [iso_to_tessarct dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py)
+
 
 Get the segments from a PDF:
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,16 @@ To install more languages in the docker container, you can use the following com
     docker exec -it --user root pdf-document-layout-analysis /bin/bash
     apt-get install tesseract-ocr-[LANGCODES]
 
-> Tesseract LANGCODES can be found in the values of the [iso_to_tesseract dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py).
+Tesseract `LANGCODES` can be found in here: [iso_to_tesseract dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py).
 
-After installing the languages into your container you should be able to see them by running:
+For example, to install "Korean" support, you can run:
+
+```
+docker exec -it --user root pdf-document-layout-analysis /bin/bash
+apt-get install tesseract-ocr-kor
+```
+
+After installing the languages you can confirm it by running:
 
 ```
 curl localhost:5060/info

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run the service:
       make start_no_gpu
 
 
-[OPTIONAL] OCR the PDF. Check supported languages (curl localhost:5060/info):
+[OPTIONAL] OCR the PDF. Check supported languages (curl localhost:5060/info) or [install more languages for OCR](#installation-of-more-languages-for-ocr):
 
     curl -X POST -F 'language=en' -F 'file=@/PATH/TO/PDF/pdf_name.pdf' localhost:5060/ocr --output ocr_document.pdf
 
@@ -261,6 +261,20 @@ For 15 pages academic paper document:
 </table>
 
 
+## Installation of More Languages for OCR
+
+OCR is made by using Tesseract OCR, which is supporting +150 languages, however, the docker image is built with only a few languages (to prevent increasing the image size even more). 
+
+More languages can be used by installing them in the docker container or installing them in your local machine (if you are running the service locally).
+
+To install more languages in the docker container, you can use the following command after the container is running:
+
+    docker exec -it --user root {CONTAINER_ID} /bin/bash
+    apt-get install tesseract-ocr-[LANGCODES]
+
+> Tesseract LANGCODES can be found in the values of the [iso_to_tesseract dict](https://github.com/huridocs/pdf-document-layout-analysis/blob/main/src/ocr/languages.py).
+
+After installing the languages into your container you should be able to see them in the response of the */info* endpoint.
 
 
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ For 15 pages academic paper document:
 
 ## Installation of More Languages for OCR
 
-OCR is made by using Tesseract OCR, which is supporting +150 languages, however, the docker image is built with only a few languages (to prevent increasing the image size even more). 
+OCR is made by using Tesseract OCR, which is supporting +150 languages, however, the docker image is built with only a few languages (image size purposes). 
 
 More languages can be used by installing them in the docker container or installing them in your local machine (if you are running the service locally).
 

--- a/src/app.py
+++ b/src/app.py
@@ -11,7 +11,7 @@ from starlette.responses import FileResponse
 
 from catch_exceptions import catch_exceptions
 from configuration import service_logger, OCR_SOURCE
-from ocr.languages import supported_languages
+from ocr.languages import supported_languages, install_language
 from ocr.ocr_pdf import ocr_pdf
 from pdf_layout_analysis.get_xml import get_xml
 from pdf_layout_analysis.run_pdf_layout_analysis import analyze_pdf
@@ -112,3 +112,10 @@ async def ocr_pdf_sync(file: UploadFile = File(...), language: str = Form("en"))
     path.write_bytes(file.file.read())
     processed_pdf_filepath = ocr_pdf(file.filename, namespace, language)
     return FileResponse(path=processed_pdf_filepath, media_type="application/pdf")
+
+@app.post("/ocr_add_language")
+@catch_exceptions
+async def ocr_add_support(language: str):
+    if install_language(language):
+        return {"status": "success"}
+    return {"status": "failed"}

--- a/src/app.py
+++ b/src/app.py
@@ -11,7 +11,7 @@ from starlette.responses import FileResponse
 
 from catch_exceptions import catch_exceptions
 from configuration import service_logger, OCR_SOURCE
-from ocr.languages import supported_languages, install_language
+from ocr.languages import supported_languages
 from ocr.ocr_pdf import ocr_pdf
 from pdf_layout_analysis.get_xml import get_xml
 from pdf_layout_analysis.run_pdf_layout_analysis import analyze_pdf
@@ -112,10 +112,3 @@ async def ocr_pdf_sync(file: UploadFile = File(...), language: str = Form("en"))
     path.write_bytes(file.file.read())
     processed_pdf_filepath = ocr_pdf(file.filename, namespace, language)
     return FileResponse(path=processed_pdf_filepath, media_type="application/pdf")
-
-@app.post("/ocr_add_language")
-@catch_exceptions
-async def ocr_add_support(language: str):
-    if install_language(language):
-        return {"status": "success"}
-    return {"status": "failed"}

--- a/src/ocr/languages.py
+++ b/src/ocr/languages.py
@@ -1,49 +1,168 @@
 import subprocess
 
 iso_to_tesseract = {
-    "en": "eng",  # English
-    "es": "spa",  # Spanish
-    "fr": "fra",  # French
-    "af": "afr",  # Afrikaans
-    "ar": "ara",  # Arabic
-    "as": "asm",  # Assamese
-    "bn": "ben",  # Bengali (Bangla)
-    "bo": "bod",  # Tibetan
-    "de": "deu",  # German
-    "el": "ell",  # Greek
-    "he": "heb",  # Hebrew
-    "hi": "hin",  # Hindi
-    "hu": "hun",  # Hungarian
-    "in": "ind",  # Indonesian
-    "ja": "jpn",  # Japanese
-    "km": "khm",  # Khmer
-    "ko": "kor",  # Korean
-    "ku": "kmr",  # Kurdish
-    "ml": "mal",  # Malayalam
-    "ms": "msa",  # Malay
-    "my": "mya",  # Burmese
-    "ne": "nep",  # Nepali
-    "nl": "nld",  # Dutch
-    "pt": "por",  # Português
-    "ro": "ron",  # Romanian
-    "ru": "rus",  # Russian
-    "si": "sin",  # Sinhalese
-    "sr": "srp",  # Serbian
-    "ta": "tam",  # Tamil
-    "th": "tha",  # Thai
-    "tr": "tur",  # Turkish
-    "uk": "ukr",  # Ukrainian
-    "ur": "urd",  # Urdu
-    "uz": "uzb",  # Uzbek
-    "zh-Hans": "chi_sim",  # Chinese (Simplified)
-    "zh-Hant": "chi_tra",  # Chinese (Traditional)
-    # "zh": "not-supported", # Chinese
-    # "tl": "not-supported", # Tagalog
-    # "sm": "not-supported", # Samoan
-    # "om": "not-supported", # Oromo (Afaan Oromo)
-    # "mg": "not-supported", # Malagasy
-    # "ab": "not-supported", # Abkhazian
-    # "aa": "not-supported", # Afar
+    "af": "afr", # Afrikaans
+    "all": "all", # Allar
+    "am": "amh", # Amharic
+    "ar": "ara", # Arabic
+    "as": "asm", # Assamese
+    "az": "aze", # Azerbaijani
+    "aze-cyrl": "aze-cyrl", # Azerbaijani (Cyrillic)
+    "be": "bel", # Belarusian
+    "bn": "ben", # Bangla
+    "bo": "bod", # Tibetan
+    "bs": "bos", # Bosnian
+    "br": "bre", # Breton
+    "bg": "bul", # Bulgarian
+    "ca": "cat", # Catalan
+    "ceb": "ceb", # Cebuano
+    "cs": "ces", # Czech
+    "zh-Hans": "chi_sim", # Chinese (Simplified)
+    "chi-sim-vert": "chi-sim-vert", # Chinese (Simplified) vertical
+    "zh-Hant": "chi_tra", # Chinese (Traditional)
+    "chi-tra-vert": "chi-tra-vert", # Chinese (Traditional) vertical
+    "chr": "chr", # Cherokee
+    "co": "cos", # Corsican
+    "cy": "cym", # Welsh
+    "da": "dan", # Danish
+    "de": "deu", # German
+    "dv": "div", # Divehi
+    "dz": "dzo", # Dzongkha
+    "el": "ell", # Greek
+    "en": "eng", # English
+    "enm": "enm", # Middle English
+    "eo": "epo", # Esperanto
+    "et": "est", # Estonian
+    "eu": "eus", # Basque
+    "fo": "fao", # Faroese
+    "fa": "fas", # Persian
+    "fil": "fil", # Filipino
+    "fi": "fin", # Finnish
+    "fr": "fra", # French
+    "frk": "frk", # Frankish
+    "frm": "frm", # Middle French
+    "fy": "fry", # Western Frisian
+    "gd": "gla", # Scottish Gaelic
+    "ga": "gle", # Irish
+    "gl": "glg", # Galician
+    "grc": "grc", # Ancient Greek
+    "gu": "guj", # Gujarati
+    "ht": "hat", # Haitian Creole
+    "he": "heb", # Hebrew
+    "hi": "hin", # Hindi
+    "hr": "hrv", # Croatian
+    "hu": "hun", # Hungarian
+    "hy": "hye", # Armenian
+    "iu": "iku", # Inuktitut
+    "id": "ind", # Indonesian
+    "is": "isl", # Icelandic
+    "it": "ita", # Italian
+    "ita-old": "ita-old", # Old Italian
+    "jv": "jav", # Javanese
+    "ja": "jpn", # Japanese
+    "jpn-vert": "jpn-vert", # Japanese vertical
+    "kn": "kan", # Kannada
+    "ka": "kat", # Georgian 
+    "kat-old": "kat-old", # Old Georgian
+    "kk": "kaz", # Kazakh
+    "km": "khm", # Khmer
+    "ky": "kir", # Kyrgyz
+    "kmr": "kmr", # Northern Kurdish
+    "ko": "kor", # Korean
+    "kor-vert": "kor-vert", # Korean vertical
+    "lo": "lao", # Lao
+    "la": "lat", # Latin
+    "lv": "lav", # Latvian
+    "lt": "lit", # Lithuanian
+    "lb": "ltz", # Luxembourgish
+    "ml": "mal", # Malayalam
+    "mr": "mar", # Marathi
+    "mk": "mkd", # Macedonian
+    "mt": "mlt", # Maltese
+    "mn": "mon", # Mongolian
+    "mi": "mri", # Māori
+    "ms": "msa", # Malay
+    "my": "mya", # Burmese
+    "ne": "nep", # Nepali
+    "nl": "nld", # Dutch
+    "no": "nor", # Norwegian
+    "oc": "oci", # Occitan
+    "or": "ori", # Odia
+    "osd": "osd", # Unknown language [osd]
+    "pa": "pan", # Punjabi
+    "pl": "pol", # Polish
+    "pt": "por", # Portuguese
+    "ps": "pus", # Pashto
+    "qu": "que", # Quechua
+    "ro": "ron", # Romanian
+    "ru": "rus", # Russian
+    "sa": "san", # Sanskrit
+    "script-arab": "script-arab", # Arabic script
+    "script-armn": "script-armn", # Armenian script
+    "script-beng": "script-beng", # Bengali script
+    "script-cans": "script-cans", # Canadian Aboriginal script
+    "script-cher": "script-cher", # Cherokee script
+    "script-cyrl": "script-cyrl", # Cyrillic script
+    "script-deva": "script-deva", # Devanagari script
+    "script-ethi": "script-ethi", # Ethiopic script
+    "script-frak": "script-frak", # Frankish script
+    "script-geor": "script-geor", # Georgian script
+    "script-grek": "script-grek", # Greek script
+    "script-gujr": "script-gujr", # Gujarati script
+    "script-guru": "script-guru", # Gurmukhi script
+    "script-hang": "script-hang", # Hangul script
+    "script-hang-vert": "script-hang-vert", # Hangul script vertical
+    "script-hans": "script-hans", 
+    "script-hans-vert": "script-hans-vert", 
+    "script-hant": "script-hant", 
+    "script-hant-vert": "script-hant-vert", 
+    "script-hebr": "script-hebr", # Hebrew script
+    "script-jpan": "script-jpan", # Japanese script
+    "script-jpan-vert": "script-jpan-vert", # Japanese script vertical
+    "script-khmr": "script-khmr", # Khmer script
+    "script-knda": "script-knda", # Kannada script
+    "script-laoo": "script-laoo", # Lao script
+    "script-latn": "script-latn", 
+    "script-mlym": "script-mlym", # Malayalam script
+    "script-mymr": "script-mymr", # Myanmar script
+    "script-orya": "script-orya", # Odia script
+    "script-sinh": "script-sinh", # Sinhala script
+    "script-syrc": "script-syrc", # Syriac script
+    "script-taml": "script-taml", # Tamil script
+    "script-telu": "script-telu", # Telugu script
+    "script-thaa": "script-thaa", # Thaana script
+    "script-thai": "script-thai", # Thai script
+    "script-tibt": "script-tibt", # Tibetan script
+    "script-viet": "script-viet", # Vietnamese script
+    "si": "sin", # Sinhala
+    "sk": "slk", # Slovak
+    "sl": "slv", # Slovenian
+    "sd": "snd", # Sindhi
+    "es": "spa", # Spanish
+    "spa-old": "spa-old", # Old Spanish
+    "sq": "sqi", # Albanian
+    "sr": "srp", # Serbian
+    "srp-latn": "srp-latn", # Serbian (Latin)
+    "su": "sun", # Sundanese
+    "sw": "swa", # Swahili
+    "sv": "swe", # Swedish
+    "syr": "syr", # Syriac
+    "ta": "tam", # Tamil
+    "tt": "tat", # Tatar
+    "te": "tel", # Telugu
+    "tg": "tgk", # Tajik
+    "th": "tha", # Thai
+    "ti": "tir", # Tigrinya
+    "to": "ton", # Tongan
+    "tr": "tur", # Turkish
+    "ug": "uig", # Uyghur
+    "uk": "ukr", # Ukrainian
+    "ur": "urd", # Urdu
+    "uz": "uzb", # Uzbek
+    "uzb-cyrl": "uzb-cyrl", # Uzbek (Cyrillic)
+    "vi": "vie", # Vietnamese
+    "yi": "yid", # Yiddish
+    "yo": "yor", # Yoruba
 }
 
 

--- a/src/ocr/languages.py
+++ b/src/ocr/languages.py
@@ -1,183 +1,51 @@
 import subprocess
 
 iso_to_tesseract = {
-    "af": "afr", # Afrikaans
-    "all": "all", # Allar
-    "am": "amh", # Amharic
-    "ar": "ara", # Arabic
-    "as": "asm", # Assamese
-    "az": "aze", # Azerbaijani
-    "aze-cyrl": "aze-cyrl", # Azerbaijani (Cyrillic)
-    "be": "bel", # Belarusian
-    "bn": "ben", # Bangla
-    "bo": "bod", # Tibetan
-    "bs": "bos", # Bosnian
-    "br": "bre", # Breton
-    "bg": "bul", # Bulgarian
-    "ca": "cat", # Catalan
-    "ceb": "ceb", # Cebuano
-    "cs": "ces", # Czech
-    "chi-sim": "chi-sim", # Chinese (Simplified)
-    "chi-sim-vert": "chi-sim-vert", # Chinese (Simplified) vertical
-    "chi-tra": "chi-tra", # Chinese (Traditional)
-    "chi-tra-vert": "chi-tra-vert", # Chinese (Traditional) vertical
-    "chr": "chr", # Cherokee
-    "co": "cos", # Corsican
-    "cy": "cym", # Welsh
-    "da": "dan", # Danish
-    "de": "deu", # German
-    "dv": "div", # Divehi
-    "dz": "dzo", # Dzongkha
-    "el": "ell", # Greek
-    "en": "eng", # English
-    "enm": "enm", # Middle English
-    "eo": "epo", # Esperanto
-    "et": "est", # Estonian
-    "eu": "eus", # Basque
-    "fo": "fao", # Faroese
-    "fa": "fas", # Persian
-    "fil": "fil", # Filipino
-    "fi": "fin", # Finnish
-    "fr": "fra", # French
-    "frk": "frk", # Frankish
-    "frm": "frm", # Middle French
-    "fy": "fry", # Western Frisian
-    "gd": "gla", # Scottish Gaelic
-    "ga": "gle", # Irish
-    "gl": "glg", # Galician
-    "grc": "grc", # Ancient Greek
-    "gu": "guj", # Gujarati
-    "ht": "hat", # Haitian Creole
-    "he": "heb", # Hebrew
-    "hi": "hin", # Hindi
-    "hr": "hrv", # Croatian
-    "hu": "hun", # Hungarian
-    "hy": "hye", # Armenian
-    "iu": "iku", # Inuktitut
-    "id": "ind", # Indonesian
-    "is": "isl", # Icelandic
-    "it": "ita", # Italian
-    "ita-old": "ita-old", # Old Italian
-    "jv": "jav", # Javanese
-    "ja": "jpn", # Japanese
-    "jpn-vert": "jpn-vert", # Japanese vertical
-    "kn": "kan", # Kannada
-    "ka": "kat", # Georgian 
-    "kat-old": "kat-old", # Old Georgian
-    "kk": "kaz", # Kazakh
-    "km": "khm", # Khmer
-    "ky": "kir", # Kyrgyz
-    "kmr": "kmr", # Northern Kurdish
-    "ko": "kor", # Korean
-    "kor-vert": "kor-vert", # Korean vertical
-    "lo": "lao", # Lao
-    "la": "lat", # Latin
-    "lv": "lav", # Latvian
-    "lt": "lit", # Lithuanian
-    "lb": "ltz", # Luxembourgish
-    "ml": "mal", # Malayalam
-    "mr": "mar", # Marathi
-    "mk": "mkd", # Macedonian
-    "mt": "mlt", # Maltese
-    "mn": "mon", # Mongolian
-    "mi": "mri", # Māori
-    "ms": "msa", # Malay
-    "my": "mya", # Burmese
-    "ne": "nep", # Nepali
-    "nl": "nld", # Dutch
-    "no": "nor", # Norwegian
-    "oc": "oci", # Occitan
-    "or": "ori", # Odia
-    "osd": "osd", # Unknown language [osd]
-    "pa": "pan", # Punjabi
-    "pl": "pol", # Polish
-    "pt": "por", # Portuguese
-    "ps": "pus", # Pashto
-    "qu": "que", # Quechua
-    "ro": "ron", # Romanian
-    "ru": "rus", # Russian
-    "sa": "san", # Sanskrit
-    "script-arab": "script-arab", # Arabic script
-    "script-armn": "script-armn", # Armenian script
-    "script-beng": "script-beng", # Bengali script
-    "script-cans": "script-cans", # Canadian Aboriginal script
-    "script-cher": "script-cher", # Cherokee script
-    "script-cyrl": "script-cyrl", # Cyrillic script
-    "script-deva": "script-deva", # Devanagari script
-    "script-ethi": "script-ethi", # Ethiopic script
-    "script-frak": "script-frak", # Frankish script
-    "script-geor": "script-geor", # Georgian script
-    "script-grek": "script-grek", # Greek script
-    "script-gujr": "script-gujr", # Gujarati script
-    "script-guru": "script-guru", # Gurmukhi script
-    "script-hang": "script-hang", # Hangul script
-    "script-hang-vert": "script-hang-vert", # Hangul script vertical
-    "script-hans": "script-hans", 
-    "script-hans-vert": "script-hans-vert", 
-    "script-hant": "script-hant", 
-    "script-hant-vert": "script-hant-vert", 
-    "script-hebr": "script-hebr", # Hebrew script
-    "script-jpan": "script-jpan", # Japanese script
-    "script-jpan-vert": "script-jpan-vert", # Japanese script vertical
-    "script-khmr": "script-khmr", # Khmer script
-    "script-knda": "script-knda", # Kannada script
-    "script-laoo": "script-laoo", # Lao script
-    "script-latn": "script-latn", 
-    "script-mlym": "script-mlym", # Malayalam script
-    "script-mymr": "script-mymr", # Myanmar script
-    "script-orya": "script-orya", # Odia script
-    "script-sinh": "script-sinh", # Sinhala script
-    "script-syrc": "script-syrc", # Syriac script
-    "script-taml": "script-taml", # Tamil script
-    "script-telu": "script-telu", # Telugu script
-    "script-thaa": "script-thaa", # Thaana script
-    "script-thai": "script-thai", # Thai script
-    "script-tibt": "script-tibt", # Tibetan script
-    "script-viet": "script-viet", # Vietnamese script
-    "si": "sin", # Sinhala
-    "sk": "slk", # Slovak
-    "sl": "slv", # Slovenian
-    "sd": "snd", # Sindhi
-    "es": "spa", # Spanish
-    "spa-old": "spa-old", # Old Spanish
-    "sq": "sqi", # Albanian
-    "sr": "srp", # Serbian
-    "srp-latn": "srp-latn", # Serbian (Latin)
-    "su": "sun", # Sundanese
-    "sw": "swa", # Swahili
-    "sv": "swe", # Swedish
-    "syr": "syr", # Syriac
-    "ta": "tam", # Tamil
-    "tt": "tat", # Tatar
-    "te": "tel", # Telugu
-    "tg": "tgk", # Tajik
-    "th": "tha", # Thai
-    "ti": "tir", # Tigrinya
-    "to": "ton", # Tongan
-    "tr": "tur", # Turkish
-    "ug": "uig", # Uyghur
-    "uk": "ukr", # Ukrainian
-    "ur": "urd", # Urdu
-    "uz": "uzb", # Uzbek
-    "uzb-cyrl": "uzb-cyrl", # Uzbek (Cyrillic)
-    "vi": "vie", # Vietnamese
-    "yi": "yid", # Yiddish
-    "yo": "yor", # Yoruba
+    "en": "eng",  # English
+    "es": "spa",  # Spanish
+    "fr": "fra",  # French
+    "af": "afr",  # Afrikaans
+    "ar": "ara",  # Arabic
+    "as": "asm",  # Assamese
+    "bn": "ben",  # Bengali (Bangla)
+    "bo": "bod",  # Tibetan
+    "de": "deu",  # German
+    "el": "ell",  # Greek
+    "he": "heb",  # Hebrew
+    "hi": "hin",  # Hindi
+    "hu": "hun",  # Hungarian
+    "in": "ind",  # Indonesian
+    "ja": "jpn",  # Japanese
+    "km": "khm",  # Khmer
+    "ko": "kor",  # Korean
+    "ku": "kmr",  # Kurdish
+    "ml": "mal",  # Malayalam
+    "ms": "msa",  # Malay
+    "my": "mya",  # Burmese
+    "ne": "nep",  # Nepali
+    "nl": "nld",  # Dutch
+    "pt": "por",  # Português
+    "ro": "ron",  # Romanian
+    "ru": "rus",  # Russian
+    "si": "sin",  # Sinhalese
+    "sr": "srp",  # Serbian
+    "ta": "tam",  # Tamil
+    "th": "tha",  # Thai
+    "tr": "tur",  # Turkish
+    "uk": "ukr",  # Ukrainian
+    "ur": "urd",  # Urdu
+    "uz": "uzb",  # Uzbek
+    "zh-Hans": "chi_sim",  # Chinese (Simplified)
+    "zh-Hant": "chi_tra",  # Chinese (Traditional)
+    # "zh": "not-supported", # Chinese
+    # "tl": "not-supported", # Tagalog
+    # "sm": "not-supported", # Samoan
+    # "om": "not-supported", # Oromo (Afaan Oromo)
+    # "mg": "not-supported", # Malagasy
+    # "ab": "not-supported", # Abkhazian
+    # "aa": "not-supported", # Afar
 }
 
-def install_language(iso_language):
-    if iso_language not in iso_to_tesseract:
-        return False
-    cmd = f"apt-get install tesseract-ocr-{iso_to_tesseract[iso_language]}"
-    sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
-    sp.communicate()
-    return sp.returncode == 0
-
-def check_if_iso_language_installed(iso_language):
-    cmd = "tesseract --list-langs | grep -v osd | awk '{if(NR>1)print}'"
-    sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
-    tesseract_langs = [line.strip().decode("utf-8") for line in sp.stdout.readlines()]
-    return iso_to_tesseract[iso_language] in tesseract_langs
 
 def supported_languages():
     cmd = "tesseract --list-langs | grep -v osd | awk '{if(NR>1)print}'"

--- a/src/ocr/languages.py
+++ b/src/ocr/languages.py
@@ -1,51 +1,183 @@
 import subprocess
 
 iso_to_tesseract = {
-    "en": "eng",  # English
-    "es": "spa",  # Spanish
-    "fr": "fra",  # French
-    "af": "afr",  # Afrikaans
-    "ar": "ara",  # Arabic
-    "as": "asm",  # Assamese
-    "bn": "ben",  # Bengali (Bangla)
-    "bo": "bod",  # Tibetan
-    "de": "deu",  # German
-    "el": "ell",  # Greek
-    "he": "heb",  # Hebrew
-    "hi": "hin",  # Hindi
-    "hu": "hun",  # Hungarian
-    "in": "ind",  # Indonesian
-    "ja": "jpn",  # Japanese
-    "km": "khm",  # Khmer
-    "ko": "kor",  # Korean
-    "ku": "kmr",  # Kurdish
-    "ml": "mal",  # Malayalam
-    "ms": "msa",  # Malay
-    "my": "mya",  # Burmese
-    "ne": "nep",  # Nepali
-    "nl": "nld",  # Dutch
-    "pt": "por",  # Português
-    "ro": "ron",  # Romanian
-    "ru": "rus",  # Russian
-    "si": "sin",  # Sinhalese
-    "sr": "srp",  # Serbian
-    "ta": "tam",  # Tamil
-    "th": "tha",  # Thai
-    "tr": "tur",  # Turkish
-    "uk": "ukr",  # Ukrainian
-    "ur": "urd",  # Urdu
-    "uz": "uzb",  # Uzbek
-    "zh-Hans": "chi_sim",  # Chinese (Simplified)
-    "zh-Hant": "chi_tra",  # Chinese (Traditional)
-    # "zh": "not-supported", # Chinese
-    # "tl": "not-supported", # Tagalog
-    # "sm": "not-supported", # Samoan
-    # "om": "not-supported", # Oromo (Afaan Oromo)
-    # "mg": "not-supported", # Malagasy
-    # "ab": "not-supported", # Abkhazian
-    # "aa": "not-supported", # Afar
+    "af": "afr", # Afrikaans
+    "all": "all", # Allar
+    "am": "amh", # Amharic
+    "ar": "ara", # Arabic
+    "as": "asm", # Assamese
+    "az": "aze", # Azerbaijani
+    "aze-cyrl": "aze-cyrl", # Azerbaijani (Cyrillic)
+    "be": "bel", # Belarusian
+    "bn": "ben", # Bangla
+    "bo": "bod", # Tibetan
+    "bs": "bos", # Bosnian
+    "br": "bre", # Breton
+    "bg": "bul", # Bulgarian
+    "ca": "cat", # Catalan
+    "ceb": "ceb", # Cebuano
+    "cs": "ces", # Czech
+    "chi-sim": "chi-sim", # Chinese (Simplified)
+    "chi-sim-vert": "chi-sim-vert", # Chinese (Simplified) vertical
+    "chi-tra": "chi-tra", # Chinese (Traditional)
+    "chi-tra-vert": "chi-tra-vert", # Chinese (Traditional) vertical
+    "chr": "chr", # Cherokee
+    "co": "cos", # Corsican
+    "cy": "cym", # Welsh
+    "da": "dan", # Danish
+    "de": "deu", # German
+    "dv": "div", # Divehi
+    "dz": "dzo", # Dzongkha
+    "el": "ell", # Greek
+    "en": "eng", # English
+    "enm": "enm", # Middle English
+    "eo": "epo", # Esperanto
+    "et": "est", # Estonian
+    "eu": "eus", # Basque
+    "fo": "fao", # Faroese
+    "fa": "fas", # Persian
+    "fil": "fil", # Filipino
+    "fi": "fin", # Finnish
+    "fr": "fra", # French
+    "frk": "frk", # Frankish
+    "frm": "frm", # Middle French
+    "fy": "fry", # Western Frisian
+    "gd": "gla", # Scottish Gaelic
+    "ga": "gle", # Irish
+    "gl": "glg", # Galician
+    "grc": "grc", # Ancient Greek
+    "gu": "guj", # Gujarati
+    "ht": "hat", # Haitian Creole
+    "he": "heb", # Hebrew
+    "hi": "hin", # Hindi
+    "hr": "hrv", # Croatian
+    "hu": "hun", # Hungarian
+    "hy": "hye", # Armenian
+    "iu": "iku", # Inuktitut
+    "id": "ind", # Indonesian
+    "is": "isl", # Icelandic
+    "it": "ita", # Italian
+    "ita-old": "ita-old", # Old Italian
+    "jv": "jav", # Javanese
+    "ja": "jpn", # Japanese
+    "jpn-vert": "jpn-vert", # Japanese vertical
+    "kn": "kan", # Kannada
+    "ka": "kat", # Georgian 
+    "kat-old": "kat-old", # Old Georgian
+    "kk": "kaz", # Kazakh
+    "km": "khm", # Khmer
+    "ky": "kir", # Kyrgyz
+    "kmr": "kmr", # Northern Kurdish
+    "ko": "kor", # Korean
+    "kor-vert": "kor-vert", # Korean vertical
+    "lo": "lao", # Lao
+    "la": "lat", # Latin
+    "lv": "lav", # Latvian
+    "lt": "lit", # Lithuanian
+    "lb": "ltz", # Luxembourgish
+    "ml": "mal", # Malayalam
+    "mr": "mar", # Marathi
+    "mk": "mkd", # Macedonian
+    "mt": "mlt", # Maltese
+    "mn": "mon", # Mongolian
+    "mi": "mri", # Māori
+    "ms": "msa", # Malay
+    "my": "mya", # Burmese
+    "ne": "nep", # Nepali
+    "nl": "nld", # Dutch
+    "no": "nor", # Norwegian
+    "oc": "oci", # Occitan
+    "or": "ori", # Odia
+    "osd": "osd", # Unknown language [osd]
+    "pa": "pan", # Punjabi
+    "pl": "pol", # Polish
+    "pt": "por", # Portuguese
+    "ps": "pus", # Pashto
+    "qu": "que", # Quechua
+    "ro": "ron", # Romanian
+    "ru": "rus", # Russian
+    "sa": "san", # Sanskrit
+    "script-arab": "script-arab", # Arabic script
+    "script-armn": "script-armn", # Armenian script
+    "script-beng": "script-beng", # Bengali script
+    "script-cans": "script-cans", # Canadian Aboriginal script
+    "script-cher": "script-cher", # Cherokee script
+    "script-cyrl": "script-cyrl", # Cyrillic script
+    "script-deva": "script-deva", # Devanagari script
+    "script-ethi": "script-ethi", # Ethiopic script
+    "script-frak": "script-frak", # Frankish script
+    "script-geor": "script-geor", # Georgian script
+    "script-grek": "script-grek", # Greek script
+    "script-gujr": "script-gujr", # Gujarati script
+    "script-guru": "script-guru", # Gurmukhi script
+    "script-hang": "script-hang", # Hangul script
+    "script-hang-vert": "script-hang-vert", # Hangul script vertical
+    "script-hans": "script-hans", 
+    "script-hans-vert": "script-hans-vert", 
+    "script-hant": "script-hant", 
+    "script-hant-vert": "script-hant-vert", 
+    "script-hebr": "script-hebr", # Hebrew script
+    "script-jpan": "script-jpan", # Japanese script
+    "script-jpan-vert": "script-jpan-vert", # Japanese script vertical
+    "script-khmr": "script-khmr", # Khmer script
+    "script-knda": "script-knda", # Kannada script
+    "script-laoo": "script-laoo", # Lao script
+    "script-latn": "script-latn", 
+    "script-mlym": "script-mlym", # Malayalam script
+    "script-mymr": "script-mymr", # Myanmar script
+    "script-orya": "script-orya", # Odia script
+    "script-sinh": "script-sinh", # Sinhala script
+    "script-syrc": "script-syrc", # Syriac script
+    "script-taml": "script-taml", # Tamil script
+    "script-telu": "script-telu", # Telugu script
+    "script-thaa": "script-thaa", # Thaana script
+    "script-thai": "script-thai", # Thai script
+    "script-tibt": "script-tibt", # Tibetan script
+    "script-viet": "script-viet", # Vietnamese script
+    "si": "sin", # Sinhala
+    "sk": "slk", # Slovak
+    "sl": "slv", # Slovenian
+    "sd": "snd", # Sindhi
+    "es": "spa", # Spanish
+    "spa-old": "spa-old", # Old Spanish
+    "sq": "sqi", # Albanian
+    "sr": "srp", # Serbian
+    "srp-latn": "srp-latn", # Serbian (Latin)
+    "su": "sun", # Sundanese
+    "sw": "swa", # Swahili
+    "sv": "swe", # Swedish
+    "syr": "syr", # Syriac
+    "ta": "tam", # Tamil
+    "tt": "tat", # Tatar
+    "te": "tel", # Telugu
+    "tg": "tgk", # Tajik
+    "th": "tha", # Thai
+    "ti": "tir", # Tigrinya
+    "to": "ton", # Tongan
+    "tr": "tur", # Turkish
+    "ug": "uig", # Uyghur
+    "uk": "ukr", # Ukrainian
+    "ur": "urd", # Urdu
+    "uz": "uzb", # Uzbek
+    "uzb-cyrl": "uzb-cyrl", # Uzbek (Cyrillic)
+    "vi": "vie", # Vietnamese
+    "yi": "yid", # Yiddish
+    "yo": "yor", # Yoruba
 }
 
+def install_language(iso_language):
+    if iso_language not in iso_to_tesseract:
+        return False
+    cmd = f"apt-get install tesseract-ocr-{iso_to_tesseract[iso_language]}"
+    sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
+    sp.communicate()
+    return sp.returncode == 0
+
+def check_if_iso_language_installed(iso_language):
+    cmd = "tesseract --list-langs | grep -v osd | awk '{if(NR>1)print}'"
+    sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
+    tesseract_langs = [line.strip().decode("utf-8") for line in sp.stdout.readlines()]
+    return iso_to_tesseract[iso_language] in tesseract_langs
 
 def supported_languages():
     cmd = "tesseract --list-langs | grep -v osd | awk '{if(NR>1)print}'"

--- a/src/ocr/languages.py
+++ b/src/ocr/languages.py
@@ -1,168 +1,168 @@
 import subprocess
 
 iso_to_tesseract = {
-    "af": "afr", # Afrikaans
-    "all": "all", # Allar
-    "am": "amh", # Amharic
-    "ar": "ara", # Arabic
-    "as": "asm", # Assamese
-    "az": "aze", # Azerbaijani
-    "aze-cyrl": "aze-cyrl", # Azerbaijani (Cyrillic)
-    "be": "bel", # Belarusian
-    "bn": "ben", # Bangla
-    "bo": "bod", # Tibetan
-    "bs": "bos", # Bosnian
-    "br": "bre", # Breton
-    "bg": "bul", # Bulgarian
-    "ca": "cat", # Catalan
-    "ceb": "ceb", # Cebuano
-    "cs": "ces", # Czech
-    "zh-Hans": "chi_sim", # Chinese (Simplified)
-    "chi-sim-vert": "chi-sim-vert", # Chinese (Simplified) vertical
-    "zh-Hant": "chi_tra", # Chinese (Traditional)
-    "chi-tra-vert": "chi-tra-vert", # Chinese (Traditional) vertical
-    "chr": "chr", # Cherokee
-    "co": "cos", # Corsican
-    "cy": "cym", # Welsh
-    "da": "dan", # Danish
-    "de": "deu", # German
-    "dv": "div", # Divehi
-    "dz": "dzo", # Dzongkha
-    "el": "ell", # Greek
-    "en": "eng", # English
-    "enm": "enm", # Middle English
-    "eo": "epo", # Esperanto
-    "et": "est", # Estonian
-    "eu": "eus", # Basque
-    "fo": "fao", # Faroese
-    "fa": "fas", # Persian
-    "fil": "fil", # Filipino
-    "fi": "fin", # Finnish
-    "fr": "fra", # French
-    "frk": "frk", # Frankish
-    "frm": "frm", # Middle French
-    "fy": "fry", # Western Frisian
-    "gd": "gla", # Scottish Gaelic
-    "ga": "gle", # Irish
-    "gl": "glg", # Galician
-    "grc": "grc", # Ancient Greek
-    "gu": "guj", # Gujarati
-    "ht": "hat", # Haitian Creole
-    "he": "heb", # Hebrew
-    "hi": "hin", # Hindi
-    "hr": "hrv", # Croatian
-    "hu": "hun", # Hungarian
-    "hy": "hye", # Armenian
-    "iu": "iku", # Inuktitut
-    "id": "ind", # Indonesian
-    "is": "isl", # Icelandic
-    "it": "ita", # Italian
-    "ita-old": "ita-old", # Old Italian
-    "jv": "jav", # Javanese
-    "ja": "jpn", # Japanese
-    "jpn-vert": "jpn-vert", # Japanese vertical
-    "kn": "kan", # Kannada
-    "ka": "kat", # Georgian 
-    "kat-old": "kat-old", # Old Georgian
-    "kk": "kaz", # Kazakh
-    "km": "khm", # Khmer
-    "ky": "kir", # Kyrgyz
-    "kmr": "kmr", # Northern Kurdish
-    "ko": "kor", # Korean
-    "kor-vert": "kor-vert", # Korean vertical
-    "lo": "lao", # Lao
-    "la": "lat", # Latin
-    "lv": "lav", # Latvian
-    "lt": "lit", # Lithuanian
-    "lb": "ltz", # Luxembourgish
-    "ml": "mal", # Malayalam
-    "mr": "mar", # Marathi
-    "mk": "mkd", # Macedonian
-    "mt": "mlt", # Maltese
-    "mn": "mon", # Mongolian
-    "mi": "mri", # Māori
-    "ms": "msa", # Malay
-    "my": "mya", # Burmese
-    "ne": "nep", # Nepali
-    "nl": "nld", # Dutch
-    "no": "nor", # Norwegian
-    "oc": "oci", # Occitan
-    "or": "ori", # Odia
-    "osd": "osd", # Unknown language [osd]
-    "pa": "pan", # Punjabi
-    "pl": "pol", # Polish
-    "pt": "por", # Portuguese
-    "ps": "pus", # Pashto
-    "qu": "que", # Quechua
-    "ro": "ron", # Romanian
-    "ru": "rus", # Russian
-    "sa": "san", # Sanskrit
-    "script-arab": "script-arab", # Arabic script
-    "script-armn": "script-armn", # Armenian script
-    "script-beng": "script-beng", # Bengali script
-    "script-cans": "script-cans", # Canadian Aboriginal script
-    "script-cher": "script-cher", # Cherokee script
-    "script-cyrl": "script-cyrl", # Cyrillic script
-    "script-deva": "script-deva", # Devanagari script
-    "script-ethi": "script-ethi", # Ethiopic script
-    "script-frak": "script-frak", # Frankish script
-    "script-geor": "script-geor", # Georgian script
-    "script-grek": "script-grek", # Greek script
-    "script-gujr": "script-gujr", # Gujarati script
-    "script-guru": "script-guru", # Gurmukhi script
-    "script-hang": "script-hang", # Hangul script
-    "script-hang-vert": "script-hang-vert", # Hangul script vertical
-    "script-hans": "script-hans", 
-    "script-hans-vert": "script-hans-vert", 
-    "script-hant": "script-hant", 
-    "script-hant-vert": "script-hant-vert", 
-    "script-hebr": "script-hebr", # Hebrew script
-    "script-jpan": "script-jpan", # Japanese script
-    "script-jpan-vert": "script-jpan-vert", # Japanese script vertical
-    "script-khmr": "script-khmr", # Khmer script
-    "script-knda": "script-knda", # Kannada script
-    "script-laoo": "script-laoo", # Lao script
-    "script-latn": "script-latn", 
-    "script-mlym": "script-mlym", # Malayalam script
-    "script-mymr": "script-mymr", # Myanmar script
-    "script-orya": "script-orya", # Odia script
-    "script-sinh": "script-sinh", # Sinhala script
-    "script-syrc": "script-syrc", # Syriac script
-    "script-taml": "script-taml", # Tamil script
-    "script-telu": "script-telu", # Telugu script
-    "script-thaa": "script-thaa", # Thaana script
-    "script-thai": "script-thai", # Thai script
-    "script-tibt": "script-tibt", # Tibetan script
-    "script-viet": "script-viet", # Vietnamese script
-    "si": "sin", # Sinhala
-    "sk": "slk", # Slovak
-    "sl": "slv", # Slovenian
-    "sd": "snd", # Sindhi
-    "es": "spa", # Spanish
-    "spa-old": "spa-old", # Old Spanish
-    "sq": "sqi", # Albanian
-    "sr": "srp", # Serbian
-    "srp-latn": "srp-latn", # Serbian (Latin)
-    "su": "sun", # Sundanese
-    "sw": "swa", # Swahili
-    "sv": "swe", # Swedish
-    "syr": "syr", # Syriac
-    "ta": "tam", # Tamil
-    "tt": "tat", # Tatar
-    "te": "tel", # Telugu
-    "tg": "tgk", # Tajik
-    "th": "tha", # Thai
-    "ti": "tir", # Tigrinya
-    "to": "ton", # Tongan
-    "tr": "tur", # Turkish
-    "ug": "uig", # Uyghur
-    "uk": "ukr", # Ukrainian
-    "ur": "urd", # Urdu
-    "uz": "uzb", # Uzbek
-    "uzb-cyrl": "uzb-cyrl", # Uzbek (Cyrillic)
-    "vi": "vie", # Vietnamese
-    "yi": "yid", # Yiddish
-    "yo": "yor", # Yoruba
+    "af": "afr",  # Afrikaans
+    "all": "all",  # Allar
+    "am": "amh",  # Amharic
+    "ar": "ara",  # Arabic
+    "as": "asm",  # Assamese
+    "az": "aze",  # Azerbaijani
+    "aze-cyrl": "aze-cyrl",  # Azerbaijani (Cyrillic)
+    "be": "bel",  # Belarusian
+    "bn": "ben",  # Bangla
+    "bo": "bod",  # Tibetan
+    "bs": "bos",  # Bosnian
+    "br": "bre",  # Breton
+    "bg": "bul",  # Bulgarian
+    "ca": "cat",  # Catalan
+    "ceb": "ceb",  # Cebuano
+    "cs": "ces",  # Czech
+    "zh-Hans": "chi_sim",  # Chinese (Simplified)
+    "chi-sim-vert": "chi-sim-vert",  # Chinese (Simplified) vertical
+    "zh-Hant": "chi_tra",  # Chinese (Traditional)
+    "chi-tra-vert": "chi-tra-vert",  # Chinese (Traditional) vertical
+    "chr": "chr",  # Cherokee
+    "co": "cos",  # Corsican
+    "cy": "cym",  # Welsh
+    "da": "dan",  # Danish
+    "de": "deu",  # German
+    "dv": "div",  # Divehi
+    "dz": "dzo",  # Dzongkha
+    "el": "ell",  # Greek
+    "en": "eng",  # English
+    "enm": "enm",  # Middle English
+    "eo": "epo",  # Esperanto
+    "et": "est",  # Estonian
+    "eu": "eus",  # Basque
+    "fo": "fao",  # Faroese
+    "fa": "fas",  # Persian
+    "fil": "fil",  # Filipino
+    "fi": "fin",  # Finnish
+    "fr": "fra",  # French
+    "frk": "frk",  # Frankish
+    "frm": "frm",  # Middle French
+    "fy": "fry",  # Western Frisian
+    "gd": "gla",  # Scottish Gaelic
+    "ga": "gle",  # Irish
+    "gl": "glg",  # Galician
+    "grc": "grc",  # Ancient Greek
+    "gu": "guj",  # Gujarati
+    "ht": "hat",  # Haitian Creole
+    "he": "heb",  # Hebrew
+    "hi": "hin",  # Hindi
+    "hr": "hrv",  # Croatian
+    "hu": "hun",  # Hungarian
+    "hy": "hye",  # Armenian
+    "iu": "iku",  # Inuktitut
+    "id": "ind",  # Indonesian
+    "is": "isl",  # Icelandic
+    "it": "ita",  # Italian
+    "ita-old": "ita-old",  # Old Italian
+    "jv": "jav",  # Javanese
+    "ja": "jpn",  # Japanese
+    "jpn-vert": "jpn-vert",  # Japanese vertical
+    "kn": "kan",  # Kannada
+    "ka": "kat",  # Georgian
+    "kat-old": "kat-old",  # Old Georgian
+    "kk": "kaz",  # Kazakh
+    "km": "khm",  # Khmer
+    "ky": "kir",  # Kyrgyz
+    "kmr": "kmr",  # Northern Kurdish
+    "ko": "kor",  # Korean
+    "kor-vert": "kor-vert",  # Korean vertical
+    "lo": "lao",  # Lao
+    "la": "lat",  # Latin
+    "lv": "lav",  # Latvian
+    "lt": "lit",  # Lithuanian
+    "lb": "ltz",  # Luxembourgish
+    "ml": "mal",  # Malayalam
+    "mr": "mar",  # Marathi
+    "mk": "mkd",  # Macedonian
+    "mt": "mlt",  # Maltese
+    "mn": "mon",  # Mongolian
+    "mi": "mri",  # Māori
+    "ms": "msa",  # Malay
+    "my": "mya",  # Burmese
+    "ne": "nep",  # Nepali
+    "nl": "nld",  # Dutch
+    "no": "nor",  # Norwegian
+    "oc": "oci",  # Occitan
+    "or": "ori",  # Odia
+    "osd": "osd",  # Unknown language [osd]
+    "pa": "pan",  # Punjabi
+    "pl": "pol",  # Polish
+    "pt": "por",  # Portuguese
+    "ps": "pus",  # Pashto
+    "qu": "que",  # Quechua
+    "ro": "ron",  # Romanian
+    "ru": "rus",  # Russian
+    "sa": "san",  # Sanskrit
+    "script-arab": "script-arab",  # Arabic script
+    "script-armn": "script-armn",  # Armenian script
+    "script-beng": "script-beng",  # Bengali script
+    "script-cans": "script-cans",  # Canadian Aboriginal script
+    "script-cher": "script-cher",  # Cherokee script
+    "script-cyrl": "script-cyrl",  # Cyrillic script
+    "script-deva": "script-deva",  # Devanagari script
+    "script-ethi": "script-ethi",  # Ethiopic script
+    "script-frak": "script-frak",  # Frankish script
+    "script-geor": "script-geor",  # Georgian script
+    "script-grek": "script-grek",  # Greek script
+    "script-gujr": "script-gujr",  # Gujarati script
+    "script-guru": "script-guru",  # Gurmukhi script
+    "script-hang": "script-hang",  # Hangul script
+    "script-hang-vert": "script-hang-vert",  # Hangul script vertical
+    "script-hans": "script-hans",
+    "script-hans-vert": "script-hans-vert",
+    "script-hant": "script-hant",
+    "script-hant-vert": "script-hant-vert",
+    "script-hebr": "script-hebr",  # Hebrew script
+    "script-jpan": "script-jpan",  # Japanese script
+    "script-jpan-vert": "script-jpan-vert",  # Japanese script vertical
+    "script-khmr": "script-khmr",  # Khmer script
+    "script-knda": "script-knda",  # Kannada script
+    "script-laoo": "script-laoo",  # Lao script
+    "script-latn": "script-latn",
+    "script-mlym": "script-mlym",  # Malayalam script
+    "script-mymr": "script-mymr",  # Myanmar script
+    "script-orya": "script-orya",  # Odia script
+    "script-sinh": "script-sinh",  # Sinhala script
+    "script-syrc": "script-syrc",  # Syriac script
+    "script-taml": "script-taml",  # Tamil script
+    "script-telu": "script-telu",  # Telugu script
+    "script-thaa": "script-thaa",  # Thaana script
+    "script-thai": "script-thai",  # Thai script
+    "script-tibt": "script-tibt",  # Tibetan script
+    "script-viet": "script-viet",  # Vietnamese script
+    "si": "sin",  # Sinhala
+    "sk": "slk",  # Slovak
+    "sl": "slv",  # Slovenian
+    "sd": "snd",  # Sindhi
+    "es": "spa",  # Spanish
+    "spa-old": "spa-old",  # Old Spanish
+    "sq": "sqi",  # Albanian
+    "sr": "srp",  # Serbian
+    "srp-latn": "srp-latn",  # Serbian (Latin)
+    "su": "sun",  # Sundanese
+    "sw": "swa",  # Swahili
+    "sv": "swe",  # Swedish
+    "syr": "syr",  # Syriac
+    "ta": "tam",  # Tamil
+    "tt": "tat",  # Tatar
+    "te": "tel",  # Telugu
+    "tg": "tgk",  # Tajik
+    "th": "tha",  # Thai
+    "ti": "tir",  # Tigrinya
+    "to": "ton",  # Tongan
+    "tr": "tur",  # Turkish
+    "ug": "uig",  # Uyghur
+    "uk": "ukr",  # Ukrainian
+    "ur": "urd",  # Urdu
+    "uz": "uzb",  # Uzbek
+    "uzb-cyrl": "uzb-cyrl",  # Uzbek (Cyrillic)
+    "vi": "vie",  # Vietnamese
+    "yi": "yid",  # Yiddish
+    "yo": "yor",  # Yoruba
 }
 
 
@@ -171,4 +171,9 @@ def supported_languages():
     sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
     tesseract_langs = [line.strip().decode("utf-8") for line in sp.stdout.readlines()]
     inverted_iso_dict = {v: k for k, v in iso_to_tesseract.items()}
-    return list({tesseract_key: inverted_iso_dict[tesseract_key] for tesseract_key in tesseract_langs}.values())
+    return list(
+        {
+            tesseract_key: inverted_iso_dict[tesseract_key]
+            for tesseract_key in tesseract_langs
+        }.values()
+    )

--- a/src/ocr/languages.py
+++ b/src/ocr/languages.py
@@ -171,9 +171,4 @@ def supported_languages():
     sp = subprocess.Popen(["/bin/bash", "-c", cmd], stdout=subprocess.PIPE)
     tesseract_langs = [line.strip().decode("utf-8") for line in sp.stdout.readlines()]
     inverted_iso_dict = {v: k for k, v in iso_to_tesseract.items()}
-    return list(
-        {
-            tesseract_key: inverted_iso_dict[tesseract_key]
-            for tesseract_key in tesseract_langs
-        }.values()
-    )
+    return list({tesseract_key: inverted_iso_dict[tesseract_key] for tesseract_key in tesseract_langs}.values())


### PR DESCRIPTION
Previously the amount of languages was limited, even they were supported by Tesseract. All supported languages from Tesseract were added with their corresponding ISO 3166-2 (if existing, otherwise the original name was saved).

# Extracting supported languages

The creation of the dict is detailed [here](https://github.com/user-attachments/files/19504893/creating_supported_languages.pdf)



# README updated

The readme.md file was also updated with instructions on how to add languages (for the OCR capabilities) to an existing docker container. 

> Note: It was attempted to create a EP to install the tesseract packages just by making an http call, but as the app is running in docker with a non-sudoer user, the installation failed due to permissions. That is why installations have to be manually done as stated in the modified readme file.


