### PR TITLE
Create funding-manifest-urls

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://huridocs.org/funding/funding.json


### PR DESCRIPTION
Required for using a funding.json as described in https://fundingjson.org